### PR TITLE
Fixed compilation problems with reboundx mpc_dev branch

### DIFF
--- a/src/gr.c
+++ b/src/gr.c
@@ -105,7 +105,7 @@ static void rebx_calculate_gr(struct reb_simulation* const sim, struct reb_parti
     // Transform to Jacobi coordinates
     const struct reb_particle source = ps[0];
 	const double mu = G*source.m;
-    reb_transformations_inertial_to_jacobi_posvelacc(ps, ps_j, ps, N);
+	reb_transformations_inertial_to_jacobi_posvelacc(ps, ps_j, ps, N, N);
     
     for (int i=1; i<N; i++){
         struct reb_particle p = ps_j[i];
@@ -159,7 +159,7 @@ static void rebx_calculate_gr(struct reb_simulation* const sim, struct reb_parti
     ps_j[0].ay = 0.;
     ps_j[0].az = 0.;
 
-    reb_transformations_jacobi_to_inertial_acc(ps, ps_j, ps, N);
+    reb_transformations_jacobi_to_inertial_acc(ps, ps_j, ps, N, N);
     for (int i=0; i<N; i++){
         particles[i].ax += ps[i].ax;
         particles[i].ay += ps[i].ay;
@@ -214,7 +214,7 @@ static double rebx_calculate_gr_hamiltonian(struct rebx_extras* const rebx, stru
 	const double mu = G*source.m;
     double* const m_j = malloc(N*sizeof(*m_j));
     rebx_calculate_jacobi_masses(ps, m_j, N);
-    reb_transformations_inertial_to_jacobi_posvel(ps, ps_j, ps, N);
+    reb_transformations_inertial_to_jacobi_posvel(ps, ps_j, ps, N, N);
 
     double T = 0.5*m_j[0]*(ps_j[0].vx*ps_j[0].vx + ps_j[0].vy*ps_j[0].vy + ps_j[0].vz*ps_j[0].vz);
     double V_PN = 0.;

--- a/src/rebxtools.c
+++ b/src/rebxtools.c
@@ -9,6 +9,32 @@
  * (could happen e.g. with barycentric coordinates with test particles and single massive body)
  */
 
+struct reb_particle rebx_get_com_without_particle(struct reb_particle com, struct reb_particle p){
+    com.x = com.x*com.m - p.x*p.m;
+    com.y = com.y*com.m - p.y*p.m;
+    com.z = com.z*com.m - p.z*p.m;
+    com.vx = com.vx*com.m - p.vx*p.m;
+    com.vy = com.vy*com.m - p.vy*p.m;
+    com.vz = com.vz*com.m - p.vz*p.m;
+    com.ax = com.ax*com.m - p.ax*p.m;
+    com.ay = com.ay*com.m - p.ay*p.m;
+    com.az = com.az*com.m - p.az*p.m;
+    com.m -= p.m; 
+
+    if (com.m > 0.){
+        com.x /= com.m;
+        com.y /= com.m;
+        com.z /= com.m;
+        com.vx /= com.m;
+        com.vy /= com.m;
+        com.vz /= com.m;
+        com.ax /= com.m;
+        com.ay /= com.m;
+        com.az /= com.m;
+    }
+    return com;
+}
+
 static inline struct reb_particle rebx_particle_minus(struct reb_particle p1, struct reb_particle p2){
     struct reb_particle p = {0};
     p.m = p1.m-p2.m;
@@ -74,7 +100,7 @@ void rebx_com_force(struct reb_simulation* const sim, struct rebx_force* const f
         }
         struct reb_particle* p = &particles[i];
         if (coordinates == REBX_COORDINATES_JACOBI){
-            com = reb_get_com_without_particle(com, *p);
+            com = rebx_get_com_without_particle(com, *p);
         }
         
         struct reb_vec3d a = calculate_force(sim, force, p, &com);
@@ -167,7 +193,7 @@ void rebxtools_com_ptm(struct reb_simulation* const sim, struct rebx_operator* c
         }
         struct reb_particle* p = &sim->particles[i];
         if (coordinates == REBX_COORDINATES_JACOBI){
-            com = reb_get_com_without_particle(com, *p);
+            com = rebx_get_com_without_particle(com, *p);
         }
         
         struct reb_particle modified_particle = calculate_step(sim, operator, p, &com, dt);


### PR DESCRIPTION
The rebxtools.c was missing the function rebx_get_com_without_particle and reb_transformations_* was missing a parameter.  I made updates to these two files in the mpc_dev branch based on fixes to the two files based I found in rebxtools.c and gr.c in https://github.com/dtamayo/reboundx

Please review your local code to see what you have on these specific lines, since you seem to be able to build libreboundx.so without problem already.
Jan
